### PR TITLE
Read Only View for Films

### DIFF
--- a/Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -74,11 +74,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478646080.259075"
+            timestampString = "478652023.358444"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "163"
-            endingLineNumber = "163"
+            startingLineNumber = "174"
+            endingLineNumber = "174"
             landmarkName = "cancelTapped(_:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -106,11 +106,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/MainVC.swift"
-            timestampString = "478599312.440798"
+            timestampString = "478648879.845314"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "60"
-            endingLineNumber = "60"
+            startingLineNumber = "63"
+            endingLineNumber = "63"
             landmarkName = "tableView(_:cellForRowAtIndexPath:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -138,11 +138,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478646080.259075"
+            timestampString = "478652023.358444"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "187"
-            endingLineNumber = "187"
+            startingLineNumber = "198"
+            endingLineNumber = "198"
             landmarkName = "saveTapped(_:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -170,11 +170,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478646413.079926"
+            timestampString = "478650645.096024"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "103"
-            endingLineNumber = "103"
+            startingLineNumber = "104"
+            endingLineNumber = "104"
             landmarkName = "formValidation()"
             landmarkType = "5">
          </BreakpointContent>
@@ -191,6 +191,38 @@
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "9"
             endingLineNumber = "9">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/MainVC.swift"
+            timestampString = "478650711.561695"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "82"
+            endingLineNumber = "82"
+            landmarkName = "tableView(_:didSelectRowAtIndexPath:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478652023.358444"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "131"
+            endingLineNumber = "131"
+            landmarkName = "setToReadOnly()"
+            landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/Favourite-Films/DetailVC.swift
+++ b/Favourite-Films/DetailVC.swift
@@ -29,6 +29,7 @@ class DetailVC: UIViewController, UITextFieldDelegate, UITextViewDelegate, UIIma
     // MARK: - Properties
     var readOnly = false
     var imagePicker: UIImagePickerController!
+    var selectedFilm = Film?()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -113,7 +114,7 @@ class DetailVC: UIViewController, UITextFieldDelegate, UITextViewDelegate, UIIma
         view.endEditing(true)
     }
     
-    // Read Only Mode - disables user interaction on all fields, hides the 'Cancel', and 'Save' buttons, hides the URL field, and displays the URL button.
+    // Read Only Mode - disables user interaction on everything and populate the views with the passed in film data.
     func setToReadOnly() {
         self.navigationItem.setLeftBarButtonItem(nil, animated: true)
         self.navigationItem.setRightBarButtonItem(nil, animated: true)
@@ -125,6 +126,16 @@ class DetailVC: UIViewController, UITextFieldDelegate, UITextViewDelegate, UIIma
         myStarView.userInteractionEnabled = false
         imdbDesc.userInteractionEnabled = false
         myReview.userInteractionEnabled = false
+        imageButton.userInteractionEnabled = false
+        
+        let film = selectedFilm!
+        imageButton.setImage(film.getFilmImage(), forState: .Normal)
+        titleField.text = film.title
+        imdbStarView.rating = Int(film.imdbRating!)
+        myStarView.rating = Int(film.myRating!)
+        imdbDesc.text = film.imdbDescription
+        myReview.text = film.myReview
+        setBackgroundImage(film.getFilmImage())
     }
     
     // Disable the 'Save' button if it's not already disabled.

--- a/Favourite-Films/MainVC.swift
+++ b/Favourite-Films/MainVC.swift
@@ -11,8 +11,10 @@ import CoreData
 
 class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
 
+    // MARK: - Outlets
     @IBOutlet weak var tableView: UITableView!
     
+    // MARK: - Properties
     var films = [Film]()
     
     override func viewDidLoad() {
@@ -37,6 +39,7 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
         tableView.estimatedRowHeight = 107.0
     }
     
+    // MARK: - Functions
     override func viewDidAppear(animated: Bool) {
         fetchAndSetResults()
         tableView.reloadData()
@@ -76,7 +79,8 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        // Use for row selection.
+        let film = films[indexPath.row]
+        performSegueWithIdentifier("goToDetailVCRead", sender: film)
     }
     
     
@@ -96,6 +100,7 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
             if let detailVC = segue.destinationViewController as? DetailVC {
                 detailVC.navTitle.title = "Film Details"
                 detailVC.readOnly = true
+                detailVC.selectedFilm = sender as? Film
             }
         }
     }


### PR DESCRIPTION
It is now possible to view the film details of one of the saved films
by tapping it’s table cell in the table view. The film details are
displayed in the detailVC but all views can’t be interacted with (i.e.
a “read only” view).
