### PR TITLE
Edit and delete films

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+
+*.xcbkptlist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist

--- a/Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Favourite-Films.xcodeproj/xcuserdata/Jess.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -74,11 +74,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478652023.358444"
+            timestampString = "478737922.752607"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "174"
-            endingLineNumber = "174"
+            startingLineNumber = "203"
+            endingLineNumber = "203"
             landmarkName = "cancelTapped(_:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -106,11 +106,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/MainVC.swift"
-            timestampString = "478648879.845314"
+            timestampString = "478728434.233765"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "63"
-            endingLineNumber = "63"
+            startingLineNumber = "64"
+            endingLineNumber = "64"
             landmarkName = "tableView(_:cellForRowAtIndexPath:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -138,11 +138,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478652023.358444"
+            timestampString = "478739222.784929"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "198"
-            endingLineNumber = "198"
+            startingLineNumber = "234"
+            endingLineNumber = "234"
             landmarkName = "saveTapped(_:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -170,11 +170,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478650645.096024"
+            timestampString = "478736276.090984"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "104"
-            endingLineNumber = "104"
+            startingLineNumber = "106"
+            endingLineNumber = "106"
             landmarkName = "formValidation()"
             landmarkType = "5">
          </BreakpointContent>
@@ -200,11 +200,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/MainVC.swift"
-            timestampString = "478650711.561695"
+            timestampString = "478728434.233765"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "82"
-            endingLineNumber = "82"
+            startingLineNumber = "86"
+            endingLineNumber = "86"
             landmarkName = "tableView(_:didSelectRowAtIndexPath:)"
             landmarkType = "5">
          </BreakpointContent>
@@ -216,12 +216,284 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Favourite-Films/DetailVC.swift"
-            timestampString = "478652023.358444"
+            timestampString = "478736276.090984"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "131"
-            endingLineNumber = "131"
-            landmarkName = "setToReadOnly()"
+            startingLineNumber = "125"
+            endingLineNumber = "125"
+            landmarkName = "setToReadOnlyMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/MainVC.swift"
+            timestampString = "478728434.233765"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "91"
+            endingLineNumber = "91"
+            landmarkName = "tableView(_:commitEditingStyle:forRowAtIndexPath:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478737922.752607"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "220"
+            endingLineNumber = "220"
+            landmarkName = "saveTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478737922.752607"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "198"
+            endingLineNumber = "198"
+            landmarkName = "cancelTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/MainVC.swift"
+            timestampString = "478731305.225371"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "118"
+            endingLineNumber = "118"
+            landmarkName = "prepareForSegue(_:sender:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736276.090984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "119"
+            endingLineNumber = "119"
+            landmarkName = "setToReadOnlyMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/MainVC.swift"
+            timestampString = "478731664.133226"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "106"
+            endingLineNumber = "106"
+            landmarkName = "addButtonTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/MainVC.swift"
+            timestampString = "478731835.953528"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "110"
+            endingLineNumber = "110"
+            landmarkName = "prepareForSegue(_:sender:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478739222.784929"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "233"
+            endingLineNumber = "233"
+            landmarkName = "saveTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478739412.297517"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "262"
+            endingLineNumber = "262"
+            landmarkName = "saveTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478737922.752607"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "202"
+            endingLineNumber = "202"
+            landmarkName = "cancelTapped(_:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736276.090984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "39"
+            endingLineNumber = "39"
+            landmarkName = "viewDidLoad()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736276.090984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "76"
+            endingLineNumber = "76"
+            landmarkName = "formValidation()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736951.115894"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "138"
+            endingLineNumber = "138"
+            landmarkName = "setToEditMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736276.090984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "134"
+            endingLineNumber = "134"
+            landmarkName = "setToReadOnlyMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478736276.090984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "137"
+            endingLineNumber = "137"
+            landmarkName = "setToEditMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478737100.358034"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "121"
+            endingLineNumber = "121"
+            landmarkName = "setToReadOnlyMode()"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Favourite-Films/DetailVC.swift"
+            timestampString = "478737922.752607"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "153"
+            endingLineNumber = "153"
+            landmarkName = "setFormInteraction(_:)"
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>

--- a/Favourite-Films/Base.lproj/Main.storyboard
+++ b/Favourite-Films/Base.lproj/Main.storyboard
@@ -156,13 +156,13 @@
                         <barButtonItem key="rightBarButtonItem" image="AddButton" id="77n-FG-pHI">
                             <color key="tintColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                             <connections>
-                                <action selector="loadDetailVC:" destination="BYZ-38-t0r" id="mk8-px-xUD"/>
+                                <action selector="addButtonTapped:" destination="BYZ-38-t0r" id="YHT-yI-67W"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="tableView" destination="IZx-cj-Ygr" id="lmS-Wm-2Bj"/>
-                        <segue destination="4nV-8l-Uds" kind="show" identifier="goToDetailVCEdit" id="dGh-Ji-Eqn"/>
+                        <segue destination="4nV-8l-Uds" kind="show" identifier="goToDetailVCAdd" id="dGh-Ji-Eqn"/>
                         <segue destination="4nV-8l-Uds" kind="show" identifier="goToDetailVCRead" id="tgu-Bw-rJE"/>
                     </connections>
                 </viewController>
@@ -265,7 +265,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="irG-BE-nEQ" userLabel="IMDbRatingSV">
                                                                 <rect key="frame" x="0.0" y="70" width="438" height="56"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="IMDb Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hmx-Nw-Yx6" userLabel="IMDb Rating Label">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="IMDb Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hmx-Nw-Yx6" userLabel="IMDb Rating Label">
                                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="26"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="26" id="93r-ZR-pzg"/>
@@ -289,7 +289,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SBO-Eo-bhM" userLabel="MyRatingSV">
                                                                 <rect key="frame" x="0.0" y="131" width="438" height="56"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="My Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfg-4z-aeg" userLabel="My Rating Label">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="My Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfg-4z-aeg" userLabel="My Rating Label">
                                                                         <rect key="frame" x="0.0" y="0.0" width="70" height="26"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="26" id="T3h-pg-Ohf"/>
@@ -314,19 +314,19 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rCN-Iu-QEq" userLabel="BottomHalfSV">
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rCN-Iu-QEq" userLabel="BottomHalfSV">
                                                 <rect key="frame" x="10" y="205" width="580" height="332"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="KxP-tK-Era" userLabel="IMDbSection">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="KxP-tK-Era" userLabel="IMDbSection">
                                                         <rect key="frame" x="0.0" y="0.0" width="580" height="161"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="IMDb Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1iA-OT-VQp" userLabel="IMDb Description Title">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IMDb Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1iA-OT-VQp" userLabel="IMDb Description Title">
                                                                 <rect key="frame" x="0.0" y="0.0" width="122" height="28"/>
                                                                 <fontDescription key="fontDescription" name="Catamaran-Regular" family="Catamaran" pointSize="17"/>
                                                                 <color key="textColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1vT-GP-3za" userLabel="IMDb Description Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1vT-GP-3za" userLabel="IMDb Description Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="28" width="580" height="133"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="577" id="Hys-41-B1f"/>
@@ -347,16 +347,16 @@
                                                             <constraint firstAttribute="trailing" secondItem="1vT-GP-3za" secondAttribute="trailing" id="NRr-hJ-Nux"/>
                                                         </constraints>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="vmY-6w-dLY" userLabel="MySection">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="vmY-6w-dLY" userLabel="MySection">
                                                         <rect key="frame" x="0.0" y="171" width="580" height="161"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="My Review" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JUc-fR-dnr" userLabel="My Review Title">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Review" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JUc-fR-dnr" userLabel="My Review Title">
                                                                 <rect key="frame" x="0.0" y="0.0" width="75" height="28"/>
                                                                 <fontDescription key="fontDescription" name="Catamaran-Regular" family="Catamaran" pointSize="17"/>
                                                                 <color key="textColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sJ3-2e-jfz" userLabel="My Review Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sJ3-2e-jfz" userLabel="My Review Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="28" width="580" height="133"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="577" id="8yA-zb-fDj"/>
@@ -418,7 +418,7 @@
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="Title" id="Wg8-rq-9ZH">
-                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="fJh-Ah-vaU">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="fJh-Ah-vaU">
                             <connections>
                                 <action selector="cancelTapped:" destination="4nV-8l-Uds" id="3qQ-q5-riK"/>
                             </connections>
@@ -481,6 +481,6 @@
         <image name="Star10" width="30" height="30"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="dGh-Ji-Eqn"/>
+        <segue reference="tgu-Bw-rJE"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Favourite-Films/Base.lproj/Main.storyboard
+++ b/Favourite-Films/Base.lproj/Main.storyboard
@@ -47,7 +47,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="580" height="107"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView userInteractionEnabled="NO" alpha="0.69999999999999996" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PlaceholderMoviePoster" translatesAutoresizingMaskIntoConstraints="NO" id="VnG-KU-1Pb">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.69999999999999996" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PlaceholderMoviePoster" translatesAutoresizingMaskIntoConstraints="NO" id="VnG-KU-1Pb">
                                                     <rect key="frame" x="0.0" y="0.0" width="580" height="107"/>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nid-03-idJ" userLabel="FilmTitlePanel">
@@ -265,7 +265,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="irG-BE-nEQ" userLabel="IMDbRatingSV">
                                                                 <rect key="frame" x="0.0" y="70" width="438" height="56"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="IMDb Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hmx-Nw-Yx6" userLabel="IMDb Rating Label">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="IMDb Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hmx-Nw-Yx6" userLabel="IMDb Rating Label">
                                                                         <rect key="frame" x="0.0" y="0.0" width="88" height="26"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="26" id="93r-ZR-pzg"/>
@@ -289,7 +289,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SBO-Eo-bhM" userLabel="MyRatingSV">
                                                                 <rect key="frame" x="0.0" y="131" width="438" height="56"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="My Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfg-4z-aeg" userLabel="My Rating Label">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="My Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfg-4z-aeg" userLabel="My Rating Label">
                                                                         <rect key="frame" x="0.0" y="0.0" width="70" height="26"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="26" id="T3h-pg-Ohf"/>
@@ -314,19 +314,19 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rCN-Iu-QEq" userLabel="BottomHalfSV">
+                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rCN-Iu-QEq" userLabel="BottomHalfSV">
                                                 <rect key="frame" x="10" y="205" width="580" height="332"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="KxP-tK-Era" userLabel="IMDbSection">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="KxP-tK-Era" userLabel="IMDbSection">
                                                         <rect key="frame" x="0.0" y="0.0" width="580" height="161"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IMDb Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1iA-OT-VQp" userLabel="IMDb Description Title">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="IMDb Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1iA-OT-VQp" userLabel="IMDb Description Title">
                                                                 <rect key="frame" x="0.0" y="0.0" width="122" height="28"/>
                                                                 <fontDescription key="fontDescription" name="Catamaran-Regular" family="Catamaran" pointSize="17"/>
                                                                 <color key="textColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1vT-GP-3za" userLabel="IMDb Description Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1vT-GP-3za" userLabel="IMDb Description Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="28" width="580" height="133"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="577" id="Hys-41-B1f"/>
@@ -347,16 +347,16 @@
                                                             <constraint firstAttribute="trailing" secondItem="1vT-GP-3za" secondAttribute="trailing" id="NRr-hJ-Nux"/>
                                                         </constraints>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="vmY-6w-dLY" userLabel="MySection">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="vmY-6w-dLY" userLabel="MySection">
                                                         <rect key="frame" x="0.0" y="171" width="580" height="161"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Review" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JUc-fR-dnr" userLabel="My Review Title">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="My Review" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JUc-fR-dnr" userLabel="My Review Title">
                                                                 <rect key="frame" x="0.0" y="0.0" width="75" height="28"/>
                                                                 <fontDescription key="fontDescription" name="Catamaran-Regular" family="Catamaran" pointSize="17"/>
                                                                 <color key="textColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sJ3-2e-jfz" userLabel="My Review Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sJ3-2e-jfz" userLabel="My Review Area" customClass="CustomTextView" customModule="Favourite_Films" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="28" width="580" height="133"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="577" id="8yA-zb-fDj"/>

--- a/Favourite-Films/DetailVC.swift
+++ b/Favourite-Films/DetailVC.swift
@@ -190,7 +190,7 @@ class DetailVC: UIViewController, UITextFieldDelegate, UITextViewDelegate, UIIma
             
             let app = UIApplication.sharedApplication().delegate as! AppDelegate
             let context = app.managedObjectContext
-            let entity = NSEntityDescription.entityForName("Film", inManagedObjectContext: context)! // Create a new Film class.
+            let entity = NSEntityDescription.entityForName("Film", inManagedObjectContext: context)! // Create a new Film class in the managed context (waiting room).
             let film = Film(entity: entity, insertIntoManagedObjectContext: context)
             film.setFilmImage(image)
             film.title = title

--- a/Favourite-Films/FilmImageButton.swift
+++ b/Favourite-Films/FilmImageButton.swift
@@ -7,14 +7,22 @@
 //
 
 import UIKit
-//@IBDesignable
-class FilmImageButton: UIButton {
 
+var imageButtonImageChangedKey = "imageButtonImageChangedKey"
+
+class FilmImageButton: UIButton {
+    
     //IBInspectables
     @IBInspectable var cornerRadius: CGFloat = 0.0 {
         didSet {
             layer.cornerRadius = cornerRadius
         }
+    }
+    
+    override func setImage(image: UIImage?, forState state: UIControlState) {
+        super.setImage(image, forState: state)
+        // Send a notification if the buttons image is changed.
+        NSNotificationCenter.defaultCenter().postNotificationName(imageButtonImageChangedKey, object: self)
     }
     
     override func awakeFromNib() {

--- a/Favourite-Films/Info.plist
+++ b/Favourite-Films/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>en_GB</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Favourite-Films/MainVC.swift
+++ b/Favourite-Films/MainVC.swift
@@ -16,6 +16,7 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
     
     // MARK: - Properties
     var films = [Film]()
+    let context = (UIApplication.sharedApplication().delegate as! AppDelegate).managedObjectContext // Get the 'managedObjectContext' property from the AppDelegate.
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -46,8 +47,6 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
     }
     
     func fetchAndSetResults() {
-        let app = UIApplication.sharedApplication().delegate as! AppDelegate // Get the AppDelegate.
-        let context = app.managedObjectContext // Get the 'managedObjectContext' property (the "data waiting room").
         let fetchRequest = NSFetchRequest(entityName: "Film") // Set up for an actual data fetch request for the specific entity.
         
         do {
@@ -59,6 +58,8 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
     }
     
     // MARK: - TableView Functions
+    
+    // Configure the table view cell, and make reusable.
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         
         if let cell = tableView.dequeueReusableCellWithIdentifier("FilmCell") as? FilmCell {
@@ -70,19 +71,36 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
         }
     }
     
+    // Define the number of sections in the table view.
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 1
     }
     
+    // Define the number of rows in the table view.
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return films.count
     }
     
+    // Tap the table view cell to view the film details.
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let film = films[indexPath.row]
         performSegueWithIdentifier("goToDetailVCRead", sender: film)
     }
     
+    // Swipe a table view cell to edit or delete a film.
+    func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        if editingStyle == .Delete {
+
+            // Locate the film to delete (i.e. the swiped film).
+            let filmToDelete = films[indexPath.row]
+            // Delete the film from the managedObjectContext.
+            context.deleteObject(filmToDelete)
+            // Re-fetch the data from core data.
+            fetchAndSetResults()
+            // Remove the deleted row from the table.
+            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+        }
+    }
     
     // MARK: - Actions
     @IBAction func loadDetailVC(sender: AnyObject!) {

--- a/Favourite-Films/MainVC.swift
+++ b/Favourite-Films/MainVC.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  MainVC.swift
 //  Favourite-Films
 //
 //  Created by Michael Jessey on 20/02/2016.
@@ -33,7 +33,7 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
         navigationItem.leftBarButtonItem?.enabled = false
         
         // Set the text of the default 'Back' button (no text, just the arrow).
-        navigationItem.title = ""
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .Plain, target: nil, action: nil)
         
         tableView.dataSource = self
         tableView.delegate = self
@@ -103,21 +103,22 @@ class MainVC: UIViewController, UITableViewDataSource, UITableViewDelegate {
     }
     
     // MARK: - Actions
-    @IBAction func loadDetailVC(sender: AnyObject!) {
-        performSegueWithIdentifier("goToDetailVCEdit", sender: nil)
+    @IBAction func addButtonTapped(sender: AnyObject!) {
+        performSegueWithIdentifier("goToDetailVCAdd", sender: nil)
     }
     
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "goToDetailVCEdit" {
+        if segue.identifier == "goToDetailVCAdd" {
             if let detailVC = segue.destinationViewController as? DetailVC {
                 detailVC.navTitle.title = "Add a Film"
+                detailVC.newRecord = true
             }
         }
         
         if segue.identifier == "goToDetailVCRead" {
             if let detailVC = segue.destinationViewController as? DetailVC {
                 detailVC.navTitle.title = "Film Details"
-                detailVC.readOnly = true
+                detailVC.newRecord = false
                 detailVC.selectedFilm = sender as? Film
             }
         }


### PR DESCRIPTION
It is now possible for the user to edit all of a film’s details by
viewing the details (tapping its table view cell), and then selecting
the ‘Edit’ button.

Also added the film image to be part of the form validation (it checks
the image has been changed and has not been set as the placeholder
image).

Added ‘.xcbkptlist’ files to the ‘.gitignore’ file.
